### PR TITLE
feat: send client sdk version info to hub app

### DIFF
--- a/bhaptics/haptic_player.py
+++ b/bhaptics/haptic_player.py
@@ -1,3 +1,4 @@
+import re
 import random
 import requests
 from enum import Enum
@@ -22,9 +23,15 @@ __is_verbose = False
 __ping_thread = None
 __ping_thread_active = False
 
+__version__ = "py 1.0.0"
+__version_number__ = 1
+__version_info__ = tuple([ int(num) for num in re.sub(r"[^\d.]", "", __version__).split('.')])
+
 __conf = {
     "applicationId": "",
     "sdkApiKey": "",
+    "sdkVersionName": __version__,
+    "sdkVersion": __version_number__
 }
 
 def __print(*args, **kwargs):
@@ -110,13 +117,15 @@ def is_client_api_verified():
     return __is_client_api_verified
 
 def initialize(appId: str, apiKey: str, verbose: bool = False):
-    global __conf, __is_verbose
+    global __conf, __is_verbose, __version__, __version_info__
 
     __is_verbose = verbose
     
     __conf = {
         "applicationId": appId,
         "sdkApiKey": apiKey,
+        "sdkVersionName": __version__,
+        "sdkVersion": __version_number__
     }
     
     udp_server.listen(callback=__udp_message_received, verbose=__is_verbose)
@@ -402,6 +411,7 @@ if __name__ == '__main__':
         verbose = False
     )
     
+    print(f"Testing bHaptics Hub Python SDK v{__version_info__}.\n")
     print("1. Open TactHub app and connect with TactSuit x40.")
     print("2. Press the play button to start the server.")
     print()

--- a/sample.py
+++ b/sample.py
@@ -33,6 +33,7 @@ if __name__ == '__main__':
         verbose = False
     )
     
+    print(f"Testing bHaptics Hub Python SDK v{player.__version__}.\n")
     print("1. Open TactHub app and connect with TactSuit x40.")
     print("2. Press the play button to start the server.")
     print()


### PR DESCRIPTION
- python sdk의 version string을 `py 1.0.0`으로 정했습니다.
  - unreal, unity와 version string을 독립적으로 갖고가야 할 것 같아서 이렇게 정했습니다.
- version string이 ios hub app에서 정상적으로 불러와지는 것을 확인했습니다.
- 내부 python hub sdk에서도 본 repository와 동일한 버젼명을 사용할 예정입니다.
  - https://github.com/bhaptics-etc/TactHub/pull/611